### PR TITLE
Update eBoxSize-1.1.pl

### DIFF
--- a/eBoxSize-1.1.pl
+++ b/eBoxSize-1.1.pl
@@ -162,7 +162,8 @@ for ($i=0; $i< $atoms; $i++){
 my $gyration_g= sqrt($dis/$atoms)/GY_BOX_RATIO;
 
 printf("%.3f\n", $gyration_g);
-
+print"@geo_center";
+print"\n";
 exit;
 
 


### PR DESCRIPTION
Many docking tools are requiring also the center, so I think it should print also the center.